### PR TITLE
exposed ability to stop socket monitoring

### DIFF
--- a/src/NetMQ/NetMQSocket.cs
+++ b/src/NetMQ/NetMQSocket.cs
@@ -400,6 +400,19 @@ namespace NetMQ
             m_socketHandle.Monitor(endpoint, events);
         }
 
+        /// <summary>
+        /// stop monitoring all enpoints for SocketEvent events.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">This object is already disposed.</exception>
+        /// <exception cref="TerminatingException">The socket has been stopped.</exception>
+        /// <exception cref="NetMQException">on failure to stop socket.</exception>
+        public void StopMonitor()
+        {
+            m_socketHandle.CheckDisposed();
+
+            m_socketHandle.Monitor(null, SocketEvents.All);
+        }
+
         #region Socket options
 
         /// <summary>

--- a/src/NetMQ/Properties/AssemblyInfo.cs
+++ b/src/NetMQ/Properties/AssemblyInfo.cs
@@ -33,9 +33,9 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.0.0.0")]
-[assembly: AssemblyFileVersion("4.0.0.0")]
-[assembly: AssemblyInformationalVersion("4.0.0.0")]
+[assembly: AssemblyVersion("4.0.0.1")]
+[assembly: AssemblyFileVersion("4.0.0.1")]
+[assembly: AssemblyInformationalVersion("4.0.0.1")]
 
 
 [assembly: InternalsVisibleTo("NetMQ.Tests,PublicKey=" +


### PR DESCRIPTION
In a current setup, there is no way to stop montoring socket once it is started - it is causes problems with binding if you try to create a socket with same address or resource leaks when you try to destroy monitor - exposed explicit method in socket to have ability to do so
